### PR TITLE
Update to more recent versions of Ubuntu runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-18.04
-          - ubuntu-20.04
+          - ubuntu-22.04
+          - ubuntu-24.04
           - windows-latest
           - macos-latest
         detekt_version:

--- a/.github/workflows/test_old.yml
+++ b/.github/workflows/test_old.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-18.04
-          - ubuntu-20.04
+          - ubuntu-22.04
+          - ubuntu-24.04
           - windows-latest
           - macos-latest
         detekt_version:


### PR DESCRIPTION
The Ubuntu 18.04 runners were removed years ago and the Ubuntu 20.04 runners are deprecated. Time to upgrade them to 22.04 and 24.04, respectively.