### PR TITLE
Upgrade to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ outputs:
     description: The path to the detekt executable
 
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
 
 branding:


### PR DESCRIPTION
We upgraded to Node 20 before, but now [that's been deprecated too.](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

Now upgrading to Node 24.